### PR TITLE
데이터센터 샘플 & 로그인 프로세스 샘플 코드 삽입

### DIFF
--- a/Chming_iOS.xcodeproj/project.pbxproj
+++ b/Chming_iOS.xcodeproj/project.pbxproj
@@ -1043,6 +1043,7 @@
 				FEE33FA21F2F181F00BF61AB /* LaunchScreen.storyboard */,
 				FEE33FAC1F30449700BF61AB /* MainStoryboard.storyboard */,
 				4CB1484B1F3064E900F8A32B /* Chming_iOS-Bridging-Header.h */,
+				FEDACE651F31C6D0004826B8 /* DataCenter.swift */,
 				71E4D5E61F304C0C00FD0F61 /* CH */,
 				4CB146001F30468200F8A32B /* GS */,
 				FEE33FAB1F30439900BF61AB /* JS */,
@@ -1058,7 +1059,6 @@
 		FEE33FAB1F30439900BF61AB /* JS */ = {
 			isa = PBXGroup;
 			children = (
-				FEDACE651F31C6D0004826B8 /* DataCenter.swift */,
 				FEDACE5E1F31C6B8004826B8 /* JSLoginTestViewController.swift */,
 				FEE33F9D1F2F181F00BF61AB /* JSGroupMain.storyboard */,
 				FEDACE671F31C74C004826B8 /* JSGroupMainViewController.swift */,

--- a/Chming_iOS/Base.lproj/JSGroupMain.storyboard
+++ b/Chming_iOS/Base.lproj/JSGroupMain.storyboard
@@ -21,8 +21,15 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kj4-a2-Oj2">
+                                <rect key="frame" x="16" y="114" width="343" height="545"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KBi-FJ-a2Y">
-                                <rect key="frame" x="148" y="318" width="78" height="30"/>
+                                <rect key="frame" x="148" y="38" width="78" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="SignUpTest"/>
                                 <connections>
@@ -30,7 +37,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lzT-pT-9sU">
-                                <rect key="frame" x="152" y="356" width="71" height="30"/>
+                                <rect key="frame" x="152" y="76" width="71" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="SignInTest"/>
                                 <connections>
@@ -40,10 +47,13 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
+                    <connections>
+                        <outlet property="labelTest" destination="kj4-a2-Oj2" id="izO-8I-Rne"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DH7-47-VMt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="201" y="691"/>
+            <point key="canvasLocation" x="215" y="691"/>
         </scene>
         <!--모임-->
         <scene sceneID="tne-QT-ifu">

--- a/Chming_iOS/DataCenter.swift
+++ b/Chming_iOS/DataCenter.swift
@@ -8,22 +8,26 @@
 
 import Foundation
 
+let userDefaultsPk:String = "userPK"
+
 enum Gender:String {
     case man
     case woman
 }
 
 struct Member {
-    let pkUser : Int
-    let email : String
-    var password : String
-    var name : String
-    var gender : Gender
-    var birthYear : Int
-    var birthMonth : Int
-    var birthDay : Int
-    var address : String
-    var profileImageUrl : String
+    let pkUser: Int
+    let email: String
+    var password: String
+    var name: String
+    var gender: Gender
+    var birthYear: Int
+    var birthMonth: Int
+    var birthDay: Int
+    var address: String
+    var profileImageUrl: String
+    var interest: eInterest
+    
     
     init(with data:[String:Any]) {
         self.pkUser = data["pkUser"] as! Int
@@ -36,9 +40,10 @@ struct Member {
         self.birthDay = data["birthDay"] as! Int
         self.address = data["address"] as! String
         self.profileImageUrl = data["profileImageUrl"] as! String
+        self.interest = eInterest(rawValue: data["interest"] as! eInterest.RawValue)!
     }
     
-    init(pkUser aPkUser:Int, email anEmail:String, password aPassword:String, name aName:String, gender aGender:Gender, birthYear aBirthYear:Int, birthMonth aBirthMonth:Int, birthDay aBirthDay:Int, address anAddress:String, profileImageUrl aProfileImageUrl:String) {
+    init(pkUser aPkUser:Int, email anEmail:String, password aPassword:String, name aName:String, gender aGender:Gender, birthYear aBirthYear:Int, birthMonth aBirthMonth:Int, birthDay aBirthDay:Int, address anAddress:String, profileImageUrl aProfileImageUrl:String, interest anInterest:eInterest) {
         self.pkUser = aPkUser
         self.email = anEmail
         self.password = aPassword
@@ -49,6 +54,7 @@ struct Member {
         self.birthDay = aBirthDay
         self.address = anAddress
         self.profileImageUrl = aProfileImageUrl
+        self.interest = anInterest
     }
     
 //    init(name aName:String, gender aGender:String) {
@@ -58,13 +64,83 @@ struct Member {
     
 }
 
-struct Group {
-    
+struct GroupOne {
+    let groupPK:Int
+    let latitude:Double
+    let longitude:Double
+    // latitude: 위도, longitude: 경도
 }
 
-struct Interest {
-    
+struct GroupDetail {
+    let pk: Int
+    let location: eLocalList
+    let interestCategory: eInterestCategory
+    let interest: eInterest
+    let name: String
+    let mainImageUrl: String?
+    let mainText: String?
+    let address: String
+    let longitude: Double
+    let latitude: Double
+    let leaderPK: Int
+    let leaderName: String
+    let memberList: [String] = []
+    // "모임 공지 사항 리스트" 프로퍼티 필요.
 }
+
+enum eLocalList:String {
+    // 지역 리스트 - https://ko.wikipedia.org/wiki/서울특별시의_행정_구역
+    case 종로구
+    case 중구
+    case 용산구
+    case 성동구
+    case 광진구
+    case 동대문구
+    case 중랑구
+    case 성북구
+    case 강북구
+    case 도봉구
+    case 노원구
+    case 은평구
+    case 서대문구
+    case 마포구
+    case 양천구
+    case 강서구
+    case 구로구
+    case 금천구
+    case 영등포구
+    case 동작구
+    case 관악구
+    case 서초구
+    case 강남구
+    case 송파구
+    case 강동구
+}
+
+enum eInterestCategory:String {
+    case 감상
+    case 스포츠
+}
+
+enum eInterest:String {
+    case 축구
+    case 야구
+    case 농구
+    case 영화
+    case 음악
+    case 연극
+}
+
+/* 관심사 리스트 - http://biki45.blogspot.kr/2015/02/blog-post_1.html
+ 감상 = [ 영화, 음악, 연극, 뮤지컬, 콘서트, 미술관, 박물관, 독서 ]
+ DIY = [ 한지공예, 목공예, 도자기공예, 가죽공예, 가구만들기, 천연비누화장품, 십자수 ]
+ 만들기 = [ 비즈공예, 리본공예, 와이어공예, 자수, 풍선아트, 종이접기, 선물포장 ]
+ 요리 = [ 한식, 중식, 일식, 양식 ]
+ 스포츠 = [ 축구, 야구, 농구, 족구, 탁구, 당구, 골프 ]
+ 운동 = [ 자전거, 등산, 마라톤, 수영, 암벽타기, 스키, 보드, 댄스, 헬스 ]
+ 애견 = [ 개, 고양이, 고슴도치, 물고기, 토끼, 파충류 ]
+ 공부 = [ 독서, 영어, 중국어, 일본어, 프랑스어, 한문 ]
+ */
 
 struct GroupJoinLike {
     
@@ -79,7 +155,16 @@ class DataCenter {
     
     static let sharedInstance = DataCenter()
     
+    
+    // MARK: //// Member 관련
     var memberList:[Member]?
+    
+    init() {
+        
+        // 임시 회원가입 데이터
+        self.memberList = [Member(pkUser: 1, email: "test@gmail.com", password: "123456", name: "mingming", gender: .man, birthYear: 2017, birthMonth: 08, birthDay: 20, address: "취밍시 취밍구 취밍동", profileImageUrl: "http://test.com", interest: .축구)]
+        
+    }
     
     func signUpWith(member aMember:Member) -> Bool {
         
@@ -114,6 +199,7 @@ class DataCenter {
         for i in vMemberList {
             if i.email == anEmail {
                 if i.password == aPassword {
+                    UserDefaults.standard.set(i.pkUser, forKey: userDefaultsPk) //User의 PK를 UserDefaults에 저장해서 다양한 뷰에서 사용합니다.
                     print("로그인 성공-!")
                     return true
                 }
@@ -127,5 +213,18 @@ class DataCenter {
         // 로그인 예제 코드 끝 - //
         
     }
+    
+    
+    // MARK: ///// 모임 관련
+    
+    // 지역 데이터인, "구"와 관심사 데이터를 받아서 모임 리스트를 리턴하는 메소드입니다.
+    func findGroupList(locationGOO:eLocalList, interest:eInterest) -> [GroupOne] {
+        // 지역 > 좌표 > { 위도, 경도 }
+        // 지역 > 모임 > 관심사 > { 그룹 리스트 }
+        // location > interest > groupList
+        
+        return [GroupOne(groupPK: 1, latitude: 100, longitude: 100)]
+    }
+    
     
 }

--- a/Chming_iOS/JSLoginTestViewController.swift
+++ b/Chming_iOS/JSLoginTestViewController.swift
@@ -27,16 +27,17 @@ class JSLoginTestViewController: UIViewController {
     
     // MARK: login start //
     @IBAction func btnSignUpTest(_ sender:UIButton) {
-        let tempMember = Member(pkUser: number, email: "blackturtle2@gmail.com", password: "123456", name: "Leejaesung", gender: .man, birthYear: 1988, birthMonth: 10, birthDay: 19, address: "인천시 계양구 작전1동", profileImageUrl: "http://www.google.com")
+        let tempMember = Member(pkUser: number, email: "blackturtle2@gmail.com", password: "123456", name: "Leejaesung", gender: .man, birthYear: 1988, birthMonth: 10, birthDay: 19, address: "인천시 계양구 작전1동", profileImageUrl: "http://www.google.com", interest: .축구)
         let signUpOkay = DataCenter.sharedInstance.signUpWith(member: tempMember)
         
         number = number + 1
         print("/////number: ", number)
         print(signUpOkay)
+        
     }
     
     @IBAction func btnSignInTest(_ sender:UIButton) {
-        let signInOkay = DataCenter.sharedInstance.signInWith(memberEmail: "blackturtle2@gmail.com", memberPassword: "123456")
+        let signInOkay = DataCenter.sharedInstance.signInWith(memberEmail: "chming@gmail.com", memberPassword: "123456")
         
         print(signInOkay)
     }

--- a/Chming_iOS/JSLoginTestViewController.swift
+++ b/Chming_iOS/JSLoginTestViewController.swift
@@ -7,8 +7,11 @@
 //
 
 import UIKit
+import Firebase
 
 class JSLoginTestViewController: UIViewController {
+    
+    @IBOutlet var labelTest:UILabel!
 
     var number:Int = 0
 
@@ -16,6 +19,18 @@ class JSLoginTestViewController: UIViewController {
     // MARK: viewDidLoad() //
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        Database.database().reference().child("GroupListMap").child("강남구").child("groupList").observeSingleEvent(of: .value, with: { (snapshot) in
+            
+            let rootData = snapshot.value as! [String:Any]
+            
+            print("///// rootData: ",rootData)
+            let myData = rootData["축구"]
+
+            print("///// myData: ", myData ?? "(no data)")
+            self.labelTest.text = "\(myData ?? "(no data)")"
+            
+        })
 
     }
 


### PR DESCRIPTION
로그인 프로세스 샘플 코드를 테스트하고, 데이터센터를 상위에 올렸습니다.

지금 만들어 놓은 DataCenter()는 최상위에 두고, 앱에서 사용되는 Structure나 enum 등을 관리하려고 합니다.
일단, 샘플로 두고, 각자 폴더에 JSDataCenter(), CHDataCenter(), GSDataCenter() 등을 만들어서 사용하도록 합니다.
각자 데이터센터를 만들어서, 싱글턴으로 사용해도 무관합니다. 🙋